### PR TITLE
Use non-zero values for initial states

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,9 +26,9 @@ function MyButton({
   );
 }
 function App() {
-  const [bill, setBill] = useState(0);
-  const [person, setPerson] = useState(0);
-  const [tip, setTip] = useState(0);
+  const [bill, setBill] = useState(10);
+  const [person, setPerson] = useState(2);
+  const [tip, setTip] = useState(10);
   const [isCustom, setIsCustom] = useState(false);
 
   const tipPerson =


### PR DESCRIPTION
This allows the user to immediately start tinkering with the bill, tip or person.  (As opposed to setting them to 0, which means the users need to change 3 values in order for the output to be anything other than 0).